### PR TITLE
feat: add parameters to provider.DestroyFilesystem() method

### DIFF
--- a/pkg/ns/nefError.go
+++ b/pkg/ns/nefError.go
@@ -14,6 +14,12 @@ func (e *NefError) Error() string {
 	return fmt.Sprintf("%s [code: %s]", e.Err, e.Code)
 }
 
+// IsNefError - checks if an error is an NefError
+func IsNefError(err error) bool {
+	_, ok := err.(*NefError)
+	return ok
+}
+
 // GetNefErrorCode - treats an error as NefError and returns its code in case of success
 func GetNefErrorCode(err error) string {
 	if nefErr, ok := err.(*NefError); ok {

--- a/pkg/ns/provider.go
+++ b/pkg/ns/provider.go
@@ -30,8 +30,7 @@ type ProviderInterface interface {
 
 	// filesystems
 	CreateFilesystem(params CreateFilesystemParams) error
-	DestroyFilesystem(path string, destroySnapshots bool) error
-	DestroyFilesystemWithClones(path string, destroySnapshots bool) error
+	DestroyFilesystem(path string, params DestroyFilesystemParams) error
 	SetFilesystemACL(path string, aclRuleSet ACLRuleSet) error
 	GetFilesystem(path string) (Filesystem, error)
 	GetFilesystemAvailableCapacity(path string) (int64, error)


### PR DESCRIPTION
BREAKING CHANGE: `provider.DestroyFilesystemWithClones()` method was removed, use `DestroyFilesystemParams.PromoteMostRecentCloneIfExists` instead.